### PR TITLE
Shrink unsafe block

### DIFF
--- a/components/gl/src/buffer/framebuffer.rs
+++ b/components/gl/src/buffer/framebuffer.rs
@@ -92,9 +92,9 @@ impl Drop for FrameBuffer {
 
 impl Buffer for FrameBuffer {
     fn bind_to(&self, gl: &Gl) {
+        // First make sure our associated render buffer is bound to RENDERBUFFER.
+        self.render_buffer.bind_to(&self.gl);
         unsafe {
-            // First make sure our associated render buffer is bound to RENDERBUFFER.
-            self.render_buffer.bind_to(&self.gl);
 
             // Now bind ourselves.
             gl.BindFramebuffer(FRAMEBUFFER, self.id);

--- a/components/gl/src/buffer/vbo.rs
+++ b/components/gl/src/buffer/vbo.rs
@@ -32,16 +32,16 @@ impl VertexBufferObject {
 
     /// Stores new vertex data, overwriting any that might already exist in this VBO.
     pub fn store_vertex_data(&mut self, data: &[f32]) {
+        self.bind_to(&self.gl);
         unsafe {
-            self.bind_to(&self.gl);
             self.gl.BufferData(
                 ARRAY_BUFFER,                                            // target
                 (data.len() * std::mem::size_of::<f32>()) as GLsizeiptr, // size of data in bytes
                 data.as_ptr() as *const GLvoid,                          // pointer to data
                 STATIC_DRAW,                                             // usage
             );
-            unbind_array_buffer_globally(&self.gl);
         }
+        unbind_array_buffer_globally(&self.gl);
     }
 }
 

--- a/components/gl/src/util.rs
+++ b/components/gl/src/util.rs
@@ -11,12 +11,11 @@ pub fn bool_from_glint(glint: GLint) -> bool {
 }
 
 pub fn opengl_version(gl: &Gl) -> String {
-    unsafe {
-        let data = CStr::from_ptr(gl.GetString(VERSION) as *const _)
+    
+        let data = unsafe { CStr::from_ptr(gl.GetString(VERSION) as *const _)
             .to_bytes()
-            .to_vec();
+            .to_vec() };
         String::from_utf8(data).unwrap()
-    }
 }
 
 pub(crate) fn create_whitespace_cstring(len: usize) -> CString {


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. 
We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html