### PR TITLE
Mark resize_viewport function as unsafe

### DIFF
--- a/components/gfx/src/headless.rs
+++ b/components/gfx/src/headless.rs
@@ -29,7 +29,7 @@ pub fn init_framebuffer_and_gl(
         RenderBuffer::new(&gl, size.width as _, size.height as _),
         &gl,
     );
-    resize_viewport(&gl, size.width as _, size.height as _);
+    unsafe { resize_viewport(&gl, size.width as _, size.height as _) };
     HeadlessGfxContent::new(headless_context, framebuffer, gl)
 }
 

--- a/components/gfx/src/lib.rs
+++ b/components/gfx/src/lib.rs
@@ -38,7 +38,7 @@ pub fn resize_window(
     windowed_context: &WindowedContext<PossiblyCurrent>,
     new_size: &PhysicalSize<u32>,
 ) {
-    resize_viewport(gl, new_size.width, new_size.height);
+    unsafe { resize_viewport(gl, new_size.width, new_size.height) };
     windowed_context.resize(*new_size);
 }
 

--- a/components/gl/src/viewport.rs
+++ b/components/gl/src/viewport.rs
@@ -1,8 +1,6 @@
 use crate::types::GLint;
 use crate::Gl;
 
-pub fn resize_viewport(gl: &Gl, new_width: u32, new_height: u32) {
-    unsafe {
-        gl.Viewport(0, 0, new_width as GLint, new_height as GLint);
-    }
+pub unsafe fn resize_viewport(gl: &Gl, new_width: u32, new_height: u32) {
+    gl.Viewport(0, 0, new_width as GLint, new_height as GLint);
 }


### PR DESCRIPTION
https://github.com/twilco/kosmonaut/blob/db1595ab48f40ce3a11014ebd440284ca6e81148/components/gl/src/viewport.rs#L4-L8
Hello, it needs to be marked as unsafe to ensure correct use and make the caller aware of the risks. It is not a good choice to mark the entire function body as unsafe, which will make the caller ignore the safety requirements that the function parameters must guarantee, the developer who calls the resize_viewport function may not notice this safety requirement.
Marking them unsafe also means that callers must make sure they know what they're doing.